### PR TITLE
fix:修复添加线uuid生成逻辑

### DIFF
--- a/src/Shape/Line.js
+++ b/src/Shape/Line.js
@@ -117,7 +117,7 @@ class Line {
 	 * @param {*} lineData
 	 */
 	renderLine(lineData) {
-		const key = getUuid()
+		const key = lineData.uuid
 		const { nodes } = this.node;
 		const shape = this.shapes[lineData.type || 'default'];
 		shape.paper = this.paper;


### PR DESCRIPTION
renderLine的uuid应该是读取lineData里面的uuid.
renderLine总共有两个地方调用，一个是渲染线的时候，一个是checkNewLine调用addLine的时候
渲染线的时候就应该用lineData里面的uuid，这样能保证重新渲染轨迹图的时候线的uuid是上次的，不新生成
checkNewLine调用addLine的时候已经有逻辑给lineData生成随机的uuid了，renderLine只需要读取即可